### PR TITLE
BUGFIX: Fix baseUri handling for Neos > 3.3

### DIFF
--- a/Classes/HalResource.php
+++ b/Classes/HalResource.php
@@ -304,7 +304,7 @@ class HalResource implements \ArrayAccess
     {
         $uri = new Uri($this->getLink($name)->getHref($variables));
 
-        if ($uri->getHost() === null) {
+        if ($uri->getHost() === null || $uri->getHost() === '') {
             $uri->setScheme($this->baseUri->getScheme());
             $uri->setHost($this->baseUri->getHost());
             $uri->setPath($this->baseUri->getPath() . $uri->getPath());


### PR DESCRIPTION
In Neos 3.3 the Uri object implements the PSR7 Uri interface wich enforces that the getHost method always returns a string. 

Since the existing implementation of getLinkValue explicitly checked for null currently the detection of host-relative urls did not work any more wich resulted in loosing the baseUri for linked resources.

This change checks for the host beeing null OR an empty string and thus supports old and new Neos versions.